### PR TITLE
Issue closure policy: Shall we close issues after a long time has passed if they haven't been resolved?

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ users can know what their official response was.
 Send GitHub the issue URL at the end of the message so that they can
 more easily find updates and further comments here.
 
+Issues will only be closed once GitHub implements / fixes them,
+or explicitly says WONTFIX, which almost never happens nowadays.
+Issues may take a long time (forever) to be fixed, so make sure that
+you are ready to keep them around on your [/issues](https://github.com/issues)
+list for a long time.
+
 ## Statement of Intent
 
 This repository is created in a spirit of positive intent and


### PR DESCRIPTION
A contributor closed the issue to remove it from his `/issues` list: https://github.com/isaacs/github/issues/388

I understand his desire, but I think we should not close such unresolved issues as that allows everyone to see if something is resolved or not.

I will solve this as a one off and clone his issue on a new one.

Consensus? @isaacs

Sorry for creating a branch on this repo, getting used to being a mod on a collab on a repo that is not mine :-)