### PR TITLE
Replace support@github.com with support.github.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Please see the README.md and
 [isaacs/github#6](https://github.com/isaacs/github/issues/6) for the reasons
 why this repository exists.
 
-If you file an issue in this repository, be sure to also email
-support@github.com and include a link to the issue you have created. Also be
+If you file an issue in this repository, be sure to also provide feedback to github through their support
+page [here](https://support.github.com/contact/feedback) and include a link to the issue you have created. Also be
 sure to add as a comment to your issue any response(s) you receive from GitHub
 regarding your issue.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ want to know what people are asking for, or ask for them to provide
 details about use cases etc, then head over to the issues list.
 
 Post an issue if you have an issue or feature request for GitHub.
-**But you should also email support@github.com, since this repo is
+**But you should also provide feedback to github through their support
+page [here](https://support.github.com/contact/feedback), since this repo is
 strictly for our own (unofficial) tracking purposes.** If they reply,
 (and they usually do, quickly) and if it is not a confidential matter
 like a security disclosure, add their reply to the issue so that other


### PR DESCRIPTION
Suggest filing feedback, issues and feature requests through GitHubs support.github.com page as they no longer allow support requests to be opened through their email.

Support requests to support@github.com will automatically be responded with an answer telling you to file a request over at https://support.github.com, at least as of current date (February, 2020).