### PR TITLE
Update README to direct people to use contact page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ want to know what people are asking for, or ask for them to provide
 details about use cases etc, then head over to the issues list.
 
 Post an issue if you have an issue or feature request for GitHub.
-**But you should also email support@github.com, since this repo is
-strictly for our own (unofficial) tracking purposes.** If they reply,
-(and they usually do, quickly) and if it is not a confidential matter
-like a security disclosure, add their reply to the issue so that other
-users can know what their official response was.
+**But you should also use https://support.github.com/contact, since
+this repo is strictly for our own (unofficial) tracking purposes.**
+If they reply, (and they usually do, quickly) and if it is not a
+confidential matter like a security disclosure, add their reply to
+the issue so that other users can know what their official response
+was.
 
 Send GitHub the issue URL at the end of the message so that they can
 more easily find updates and further comments here.


### PR DESCRIPTION
I sent an e-mail to support@github.com and got this autoreply:

> We now require that new support requests be created using our Support website:
> https://support.github.com/contact
> If you wouldn't mind re-submitting your message using that form, we'll be happy to help out however we can as soon as we have the opportunity.