### PR TITLE
Using support@github.com now is deprecated, switch to feedback form

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ details about use cases. Then head over to the issues list.
 
 1. Search for existing [issues](https://github.com/isaacs/github/issues)
 2. If you did not find any existing issue for your topic, post a new issue 
-3. **Additionally, please email support@github.com because this repo is strictly for our own (unofficial) tracking purposes.** 
+3. **Additionally, please send feedback at https://support.github.com/contact/feedback because this repo is strictly for our own (unofficial) tracking purposes.** 
    Make sure to send GitHub the issue URL at the end of the message so that they can
    more easily find updates and further comments here.
 4. If GitHub replies, (and they usually do, quickly) and if it is not a confidential matter


### PR DESCRIPTION
Currently sending email to support@github.com returns following answer:

> ## Please do not write below this line ##
> 
> Hi there,
> 
> We now require that new support requests be created using our Support website:
> 
> https://support.github.com
> 
> Please use this website to search through resources that may help you find the solutions you are looking for or connect with our GitHub experts.
> 
> Thank you,
> GitHub Support
> 
> **Please do not reply to this email, as it will not be seen by our team.**
> This email is a service from GitHub Support.

So replace email with new [feedback link](https://support.github.com/contact/feedback)